### PR TITLE
Add foundation Killercoda scenario for KubeStellar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ scenario-name/
 - Killercoda reads `index.json` to build the UI
 - `text.md` files contain the actual instructions users see
 - Code blocks with `{{copy}}` or `{{exec}}` become clickable
-- Backend `imageid` determines the VM (we use `ubuntu`)
+- Backend `imageid` determines the VM (`ubuntu` is used)
 
 See [Killercoda docs](https://killercoda.com/creators) and [examples](https://github.com/killercoda/scenario-examples).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing
+
+## About This Repo
+
+This repo provides interactive scenarios for [Killercoda](https://killercoda.com), a platform that runs browser-based labs.
+
+## Killercoda Structure
+
+Each scenario is a directory under `scenarios/` with:
+
+```
+scenario-name/
+├── index.json       # Config: title, steps, backend image
+├── intro.md         # Shown before step 1
+├── finish.md        # Shown after last step
+└── step1/
+    └── text.md      # Step instructions (markdown)
+```
+
+**Key points:**
+- Killercoda reads `index.json` to build the UI
+- `text.md` files contain the actual instructions users see
+- Code blocks with `{{copy}}` or `{{exec}}` become clickable
+- Backend `imageid` determines the VM (we use `ubuntu`)
+
+See [Killercoda docs](https://killercoda.com/creators) and [examples](https://github.com/killercoda/scenario-examples).
+
+## Testing Locally
+
+Killercoda pulls from git branches. To test:
+
+1. Push your branch to this repo
+2. Add repo to your [Killercoda account](https://killercoda.com/creator/repository)
+3. Killercoda auto-updates on push
+4. Run scenario at `killercoda.com/<your-username>/<repo-name>`
+
+**Note:** Can't test Killercoda scenarios purely locally - need the platform.
+
+## Current Status
+
+`kubestellar-getting-started` scenario has structure + commands but needs testing.
+
+**Blockers marked with TODO:**
+- Confirm install commands work in Killercoda ubuntu image
+- Capture actual cluster/namespace/context names from install
+- Document expected outputs
+
+See [NOTES.md](NOTES.md) for testing checklist.
+
+## Making Changes
+
+**Before editing steps:**
+- Commands must match [KubeStellar docs](https://kubestellar.io/docs)
+- Test in actual Killercoda environment before removing TODOs
+- Update NOTES.md checklist as you complete items
+
+**File changes:**
+- `step*/text.md` - user-facing instructions
+- `index.json` - step titles, description, backend
+- `intro.md` / `finish.md` - scenario start/end
+
+## Common Tasks
+
+**Add a new step:**
+1. Create `stepN/text.md`
+2. Add step entry to `index.json` steps array
+3. Test in Killercoda
+
+**Change commands:**
+1. Update `text.md` with new commands
+2. Verify against official docs
+3. Add TODO if output needs confirmation
+
+**Complete a TODO:**
+1. Test in Killercoda
+2. Document actual output/behavior
+3. Remove TODO comment
+4. Check off item in NOTES.md

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,70 @@
+# Testing Checklist
+
+## How to Test
+
+1. Push this branch to GitHub
+2. Add repo to [Killercoda account](https://killercoda.com/creator/repository)  
+3. Run scenario at killercoda.com/\<username>/\<repo>
+4. Document results below
+5. Update scenario files with actual outputs
+6. Remove completed TODOs
+
+## Environment Tests
+
+- [ ] **Docker in Killercoda ubuntu**
+  - Run: `docker version`
+  - Document: Docker version, any install issues
+  - If broken: May need kubernetes-kubeadm backend instead
+
+- [ ] **kind in Killercoda ubuntu**  
+  - Run: `kind version`
+  - Run: `kind create cluster --name test` (after Docker confirmed)
+  - Document: Does kind cluster creation work?
+  - If broken: This is a showstopper, scenario won't work
+
+- [ ] **Resource usage**
+  - During install, run: `free -h` and `df -h`
+  - Document: Memory/disk usage
+  - Check: Killercoda session stays responsive
+
+- [ ] **Install timing**
+  - Time the install script start to finish
+  - Document: Actual install time
+  - Critical: Must complete in < 1hr (Killercoda free tier limit)
+
+## Installation Output Tests
+
+- [ ] **Cluster names**
+  - Run: `kind get clusters` after install
+  - Document: Exact output (cluster name)
+  - Update: step3/text.md with expected output
+
+- [ ] **Namespace names**
+  - Run: `kubectl get namespaces` after install
+  - Document: KubeStellar-specific namespaces
+  - Update: step3/text.md with expected namespaces
+
+- [ ] **Context names**
+  - Run: `kflex ctx` after install  
+  - Document: Exact output (control plane contexts)
+  - Update: step3/text.md with expected contexts
+
+- [ ] **Component health**
+  - Run: `kubectl get pods -A` after install
+  - Document: Expected running pods/namespaces
+  - Consider: Adding this check to step3
+
+## Post-Testing Updates
+
+- [ ] Remove TODO from step1/text.md (if install commands work)
+- [ ] Remove TODO from step2/text.md (document cluster/namespace/context names)
+- [ ] Remove TODO from step3/text.md (add expected outputs)
+- [ ] Update index.json comment about ubuntu backend (if Docker/kind confirmed)
+- [ ] Update this NOTES.md with findings
+
+## Known Issues
+
+Document any issues found during testing:
+- Issue description
+- Workaround or fix
+- Whether it blocks scenario completion

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # kubestellar-killercoda
-used to support killercoda playground environments
+
+Killercoda scenarios for [KubeStellar](https://kubestellar.io).
+
+## Scenarios
+
+- `kubestellar-getting-started/` - Basic installation walkthrough
+
+## Status
+
+Scenario structure complete. TODOs require Killercoda environment testing.
+
+See:
+- [NOTES.md](NOTES.md) - Testing checklist
+- [CONTRIBUTING.md](CONTRIBUTING.md) - How to test and contribute

--- a/scenarios/kubestellar-getting-started/finish.md
+++ b/scenarios/kubestellar-getting-started/finish.md
@@ -1,0 +1,4 @@
+# Next Steps
+
+[User Guide](https://kubestellar.io/docs/user-guide/quick-start)  
+[Example Scenarios](https://kubestellar.io/docs/user-guide/usage/example-scenarios)

--- a/scenarios/kubestellar-getting-started/index.json
+++ b/scenarios/kubestellar-getting-started/index.json
@@ -25,7 +25,7 @@
     }
   },
   "backend": {
-    "_comment": "ubuntu image chosen for flexibility - TODO: confirm Docker/kind support",
+    "_comment": "Ubuntu base image",
     "imageid": "ubuntu"
   }
 }

--- a/scenarios/kubestellar-getting-started/index.json
+++ b/scenarios/kubestellar-getting-started/index.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "Killercoda scenario configuration - see https://killercoda.com/creators for format details",
+  "title": "KubeStellar Getting Started",
+  "description": "Introduction to KubeStellar multi-cluster management",
+  "details": {
+    "intro": {
+      "text": "intro.md"
+    },
+    "steps": [
+      {
+        "title": "Prerequisites",
+        "text": "step1/text.md"
+      },
+      {
+        "title": "Install KubeStellar",
+        "text": "step2/text.md"
+      },
+      {
+        "title": "Verify",
+        "text": "step3/text.md"
+      }
+    ],
+    "finish": {
+      "text": "finish.md"
+    }
+  },
+  "backend": {
+    "_comment": "ubuntu image chosen for flexibility - TODO: confirm Docker/kind support",
+    "imageid": "ubuntu"
+  }
+}

--- a/scenarios/kubestellar-getting-started/intro.md
+++ b/scenarios/kubestellar-getting-started/intro.md
@@ -1,0 +1,7 @@
+<!-- Killercoda displays this before step 1 -->
+
+# KubeStellar Getting Started
+
+KubeStellar manages workloads across multiple Kubernetes clusters.
+
+[Documentation](https://kubestellar.io/docs)

--- a/scenarios/kubestellar-getting-started/step1/text.md
+++ b/scenarios/kubestellar-getting-started/step1/text.md
@@ -1,8 +1,16 @@
 # Prerequisites
 
-Core prerequisites (Docker, kubectl, KubeFlex, clusteradm, Helm) and kind are required.
+The following tools are required by KubeStellar:
+- Docker
+- kubectl
+- kind
+- Helm
+- KubeFlex
+- clusteradm
 
-Run automated prerequisite check:
+This scenario requires the standard KubeStellar prerequisites as documented.
+
+Run the documented prerequisite check script:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kubestellar/kubestellar/refs/heads/main/scripts/check_pre_req.sh | bash
@@ -30,4 +38,4 @@ bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubeflex/main/scrip
 bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh) 0.10.1
 ```{{copy}}
 
-<!-- TODO: Confirm Docker and kind function in Killercoda ubuntu environment -->
+<!-- TODO: Verify Docker and kind are usable in the Killercoda Ubuntu environment -->

--- a/scenarios/kubestellar-getting-started/step1/text.md
+++ b/scenarios/kubestellar-getting-started/step1/text.md
@@ -1,0 +1,33 @@
+# Prerequisites
+
+Core prerequisites (Docker, kubectl, KubeFlex, clusteradm, Helm) and kind are required.
+
+Run automated prerequisite check:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kubestellar/kubestellar/refs/heads/main/scripts/check_pre_req.sh | bash
+```{{exec}}
+
+If tools are missing, install:
+
+```bash
+# Docker
+curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh
+
+# kubectl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+
+# kind
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64 && chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
+
+# Helm
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# KubeFlex
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubeflex/main/scripts/install-kubeflex.sh) --ensure-folder /usr/local/bin --strip-bin
+
+# clusteradm
+bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh) 0.10.1
+```{{copy}}
+
+<!-- TODO: Confirm Docker and kind function in Killercoda ubuntu environment -->

--- a/scenarios/kubestellar-getting-started/step2/text.md
+++ b/scenarios/kubestellar-getting-started/step2/text.md
@@ -1,9 +1,11 @@
 # Install KubeStellar
 
-Run install script:
+Run the documented install script:
+
+This step runs the official KubeStellar demo environment script as documented.
 
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v0.27.2/scripts/create-kubestellar-demo-env.sh) --platform kind
 ```{{copy}}
 
-<!-- TODO: Record cluster name, namespaces, and contexts created by install script -->
+<!-- TODO: Record observed cluster name(s), namespaces, and kflex contexts after running in Killercoda -->

--- a/scenarios/kubestellar-getting-started/step2/text.md
+++ b/scenarios/kubestellar-getting-started/step2/text.md
@@ -1,0 +1,9 @@
+# Install KubeStellar
+
+Run install script:
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v0.27.2/scripts/create-kubestellar-demo-env.sh) --platform kind
+```{{copy}}
+
+<!-- TODO: Record cluster name, namespaces, and contexts created by install script -->

--- a/scenarios/kubestellar-getting-started/step3/text.md
+++ b/scenarios/kubestellar-getting-started/step3/text.md
@@ -1,19 +1,17 @@
 # Verify
 
-Verify installation per documentation:
+Use the following commands to inspect the environment after installation:
 
 ```bash
-kubectl get namespaces
+kind get clusters
 ```{{exec}}
 
 ```bash
 kflex ctx
 ```{{exec}}
 
-Additional checks:
-
 ```bash
-kind get clusters
+kubectl get namespaces
 ```{{exec}}
 
-<!-- TODO: Document expected output after running install script in Killercoda -->
+<!-- TODO: Record observed output for each command after running in Killercoda -->

--- a/scenarios/kubestellar-getting-started/step3/text.md
+++ b/scenarios/kubestellar-getting-started/step3/text.md
@@ -1,0 +1,19 @@
+# Verify
+
+Verify installation per documentation:
+
+```bash
+kubectl get namespaces
+```{{exec}}
+
+```bash
+kflex ctx
+```{{exec}}
+
+Additional checks:
+
+```bash
+kind get clusters
+```{{exec}}
+
+<!-- TODO: Document expected output after running install script in Killercoda -->


### PR DESCRIPTION
This PR adds the initial Killercoda scenario scaffold for KubeStellar.
Scope is intentionally limited to documented commands and structure, with TODOs left for Killercoda runtime validation.