### PR TITLE
feature : added “Multi-WEC / Realistic Topology

### DIFF
--- a/scenarios/multi-wec-topology/finish.md
+++ b/scenarios/multi-wec-topology/finish.md
@@ -1,0 +1,55 @@
+# Scenario Complete: Multi-WEC Scaling with KubeStellar
+
+You have successfully completed this scenario 🎉
+
+---
+
+## What you accomplished
+
+In this scenario, you:
+
+- Installed KubeStellar in a fresh environment
+- Created multiple Workload Execution Clusters (WECs)
+- Deployed a workload **once**
+- Controlled placement using **BindingPolicy**
+- Scaled the workload to multiple clusters **without changing the workload**
+
+Most importantly, you scaled **by changing intent**, not deployment logic.
+
+---
+
+## Key takeaways
+
+- You never applied workloads directly to WECs
+- Cluster count did not change how you worked
+- BindingPolicies define **where workloads should run**
+- KubeStellar distributes Kubernetes objects automatically
+
+> **Scaling with KubeStellar is a policy change, not a deployment change.**
+
+---
+
+## What this means in real environments
+
+As the number of clusters grows:
+- You do not add scripts
+- You do not duplicate manifests
+- You do not manage clusters individually
+
+KubeStellar allows platform teams to manage **many clusters as one logical system**.
+
+---
+
+## Where to go next
+
+You can now:
+
+- Explore **BindingPolicy behavior in more detail**
+- Experiment with different cluster selections
+- Try additional KubeStellar scenarios
+
+For more information, see:
+- https://kubestellar.io
+- https://github.com/kubestellar/kubestellar
+
+Thanks for trying KubeStellar!

--- a/scenarios/multi-wec-topology/index.json
+++ b/scenarios/multi-wec-topology/index.json
@@ -1,0 +1,30 @@
+{
+  "title": "KubeStellar: Multi-WEC Topology (Scale & Confidence)",
+  "description": "Demonstrate how a single workload scales across multiple Workload Execution Clusters using BindingPolicy intent.",
+  "details": {
+    "intro": {
+      "text": "intro.md"
+    },
+    "steps": [
+      {
+        "title": "install KubeStellar and Create Multiple WECs",
+        "text": "step1/text.md"
+      },
+      {
+        "title": "Initial Placement: Single WEC",
+        "text": "step2/text.md"
+      },
+      {
+        "title": "Scale Out: Multi-WEC Propagation via Policy",
+        "text": "step3/text.md"
+      }
+    ],
+    "finish": {
+      "text": "finish.md"
+    }
+  },
+  "backend": {
+    "_comment": "Ubuntu base image",
+    "imageid": "ubuntu"
+  }
+}

--- a/scenarios/multi-wec-topology/intro.md
+++ b/scenarios/multi-wec-topology/intro.md
@@ -1,0 +1,40 @@
+# KubeStellar: Multi-WEC Topology
+
+In this scenario, you will see how **KubeStellar scales from one cluster to many** without changing how workloads are defined or deployed.
+
+In real environments, platform teams manage:
+- Multiple Kubernetes clusters
+- Different regions, zones, or edge locations
+- Growing numbers of Workload Execution Clusters (WECs)
+
+KubeStellar is designed so that **adding more clusters does not add more operational complexity**.
+
+---
+
+## What you will do
+
+In this scenario, you will:
+
+- Install KubeStellar in a fresh environment
+- Create multiple Workload Execution Clusters (WECs)
+- Deploy a workload **once**
+- Use a BindingPolicy to control where that workload runs
+- Scale the workload to multiple clusters **by changing policy only**
+
+---
+
+## What you will NOT do
+
+- You will not run `kubectl apply` against WEC clusters
+- You will not copy manifests between clusters
+- You will not manage per-cluster deployments
+
+KubeStellar handles distribution for you.
+
+---
+
+## Key idea to keep in mind
+
+> **Scaling with KubeStellar is a policy change, not a deployment change.**
+
+When you are ready, continue to install KubeStellar and set up a multi-cluster environment.

--- a/scenarios/multi-wec-topology/step1/text.md
+++ b/scenarios/multi-wec-topology/step1/text.md
@@ -1,0 +1,125 @@
+# Install KubeStellar and Create a Multi-WEC Environment
+
+In this step, you will set up a fresh multi-cluster environment and install **KubeStellar**.
+
+This scenario is self-contained. Everything is installed from scratch.
+
+---
+
+## Verify prerequisites
+
+KubeStellar requires Docker and Kubernetes tooling.  
+First, confirm Docker is available in this environment.
+
+```bash
+docker version
+```{}
+
+> If Docker is not available or fails here, this scenario cannot proceed.
+
+---
+
+## Install kind (Kubernetes in Docker)
+
+We will use **kind** to create multiple Kubernetes clusters locally.
+
+```bash
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+```{}
+
+Verify the installation:
+
+```bash
+kind version
+```{}
+
+---
+
+## Create Kubernetes clusters
+
+Create one hosting cluster and **two Workload Execution Clusters (WECs)**.
+
+```bash
+kind create cluster --name hosting
+kind create cluster --name wec1
+kind create cluster --name wec2
+```{}
+
+Verify that all clusters were created:
+
+```bash
+kind get clusters
+```{}
+
+You should see output similar to:
+hosting
+wec1
+wec2
+---
+
+## Install kubectl
+
+Install `kubectl` to interact with the Kubernetes clusters.
+
+```bash
+curl -LO https://dl.k8s.io/release/v1.30.0/bin/linux/amd64/kubectl
+chmod +x kubectl
+sudo mv kubectl /usr/local/bin/
+```{}
+
+Verify the installation:
+
+```bash
+kubectl version --client
+```{}
+
+---
+
+## Install KubeStellar
+
+Clone the KubeStellar repository:
+
+```bash
+git clone https://github.com/kubestellar/kubestellar.git
+cd kubestellar
+```{}
+
+Install KubeStellar using the demo environment script:
+
+```bash
+./scripts/create-kubestellar-demo-env.sh
+```{}
+
+> ⏳ This step may take several minutes to complete.
+
+---
+
+## Verify KubeStellar installation
+
+Check that KubeStellar namespaces exist:
+
+```bash
+kubectl get namespaces
+```{}
+
+Check that KubeStellar CRDs are installed:
+
+```bash
+kubectl get crds | grep kubestellar
+```{}
+
+Verify that all KubeStellar components are running:
+
+```bash
+kubectl get pods -A
+```{}
+
+At this point, you should have:
+
+- One hosting/control environment
+- Two Workload Execution Clusters (WECs)
+- KubeStellar fully installed and running
+
+Continue to the next step to deploy a workload and observe initial placement.

--- a/scenarios/multi-wec-topology/step2/text.md
+++ b/scenarios/multi-wec-topology/step2/text.md
@@ -1,0 +1,104 @@
+# Initial Placement: Deploy to a Single WEC
+
+In this step, you will deploy a workload **once** and use a **BindingPolicy** to place it on **one Workload Execution Cluster (WEC)**.
+
+At this stage, the workload will run only on **wec1**.
+
+---
+
+## Define the workload
+
+Create a simple Kubernetes Deployment.  
+This workload will not reference any cluster directly.
+
+```bash
+cat <<EOF > workload.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-nginx
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-nginx
+  template:
+    metadata:
+      labels:
+        app: demo-nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:stable
+        ports:
+        - containerPort: 80
+EOF
+```{}
+
+---
+
+## Define a BindingPolicy for a single WEC
+
+Now create a BindingPolicy that targets **only `wec1`**.
+
+```bash
+cat <<EOF > bindingpolicy-wec1.yaml
+apiVersion: control.kubestellar.io/v1alpha1
+kind: BindingPolicy
+metadata:
+  name: demo-nginx-to-wec1
+spec:
+  clusterSelectors:
+  - matchLabels:
+      kubestellar.io/cluster-name: wec1
+  downsync:
+  - objectSelectors:
+    - matchLabels:
+        app: demo-nginx
+EOF
+```{}
+
+---
+
+## Apply the workload and policy
+
+Apply both resources **once**, from the control environment.
+
+```bash
+kubectl apply -f workload.yaml
+kubectl apply -f bindingpolicy-wec1.yaml
+```{}
+
+> ⚠️ Do **not** apply these manifests directly to `wec1`.
+> KubeStellar handles distribution automatically.
+
+---
+
+## Observe workload placement
+
+Check that the workload is running on **wec1**:
+
+```bash
+kubectl --context wec1 get pods
+```{}
+
+You should see a pod for `demo-nginx` running.
+
+Now confirm that the workload is **not** running on `wec2`:
+
+```bash
+kubectl --context wec2 get pods
+```{}
+
+You should see **no pods** for this workload on `wec2`.
+
+---
+
+## Key takeaway
+
+- The workload was applied **once**
+- Placement was controlled entirely by **BindingPolicy**
+- Only `wec1` received the workload
+
+In the next step, you will scale this workload to **multiple WECs** by changing **policy only**.

--- a/scenarios/multi-wec-topology/step3/text.md
+++ b/scenarios/multi-wec-topology/step3/text.md
@@ -1,0 +1,83 @@
+# Scale Out: Multi-WEC Propagation via Policy
+
+In this step, you will scale the workload from **one cluster to multiple clusters** by changing **only the BindingPolicy**.
+
+The workload definition will remain unchanged.
+
+---
+
+## Update the BindingPolicy to target multiple WECs
+
+Create a new BindingPolicy that targets **both `wec1` and `wec2`**.
+
+```bash
+cat <<EOF > bindingpolicy-multi-wec.yaml
+apiVersion: control.kubestellar.io/v1alpha1
+kind: BindingPolicy
+metadata:
+  name: demo-nginx-to-multi-wec
+spec:
+  clusterSelectors:
+  - matchLabels:
+      kubestellar.io/cluster-name: wec1
+  - matchLabels:
+      kubestellar.io/cluster-name: wec2
+  downsync:
+  - objectSelectors:
+    - matchLabels:
+        app: demo-nginx
+EOF
+```{}
+
+---
+
+## Apply the updated BindingPolicy
+
+Apply the new policy from the control environment:
+
+```bash
+kubectl apply -f bindingpolicy-multi-wec.yaml
+```{}
+
+> The workload itself is **not** modified or reapplied.
+
+---
+
+## Observe workload propagation
+
+Verify that the workload is running on **both WECs**.
+
+Check `wec1`:
+
+```bash
+kubectl --context wec1 get pods
+```{}
+
+Check `wec2`:
+
+```bash
+kubectl --context wec2 get pods
+```{}
+
+You should now see a `demo-nginx` pod running in **both clusters**.
+
+---
+
+## Confirm identical behavior
+
+Both clusters received:
+- The same workload
+- From the same definition
+- Without per-cluster deployment commands
+
+This demonstrates that **cluster count does not increase operational complexity**.
+
+---
+
+## Key takeaway
+
+- Scaling is achieved by **changing intent**
+- Workloads remain unchanged
+- KubeStellar distributes Kubernetes objects across clusters automatically
+
+Continue to the final step to summarize what you learned.


### PR DESCRIPTION
This PR adds Scenario 3 to the KubeStellar Killercoda tutorials:
Multi-WEC / Realistic Topology (Scale & Confidence).

The scenario demonstrates how KubeStellar scales from one to multiple Workload Execution Clusters (WECs) without changing workload manifests, using BindingPolicy-driven intent.

This scenario builds on the concepts introduced in earlier scenarios but is fully self-contained and can be run independently.

What this scenario shows

A fresh installation of KubeStellar in a Killercoda environment

Multiple Kubernetes clusters (one control environment + multiple WECs)

A workload deployed once

Initial placement on a single WEC via BindingPolicy

Scaling out to multiple WECs by changing policy only

No direct kubectl apply to WEC clusters

The goal is to give users confidence that:

“Adding more clusters does not increase operational complexity when using KubeStellar.”

fixes #9 