### PR TITLE
feat(killercoda): add  – BindingPolicy in Action

### DIFF
--- a/scenarios/bindingpolicy-in-action/finish.md
+++ b/scenarios/bindingpolicy-in-action/finish.md
@@ -1,0 +1,58 @@
+# Scenario Complete: BindingPolicy in Action
+
+You have successfully completed this scenario ..
+
+---
+
+## What you accomplished
+
+In this scenario, you:
+
+- Installed KubeStellar in a fresh environment
+- Created multiple Workload Execution Clusters (WECs)
+- Deployed a workload **once**
+- Used a BindingPolicy to control where the workload runs
+- Changed workload placement **without modifying or redeploying the workload**
+
+Most importantly, you saw how **changing intent changes behavior**.
+
+---
+
+## Key takeaways
+
+- Workloads are defined independently of clusters
+- BindingPolicies express **where workloads should run**
+- Changing a BindingPolicy automatically changes placement
+- You never applied workloads directly to WEC clusters
+
+> **With KubeStellar, intent drives placement — not deployment logic.**
+
+---
+
+## Why this matters
+
+In traditional multi-cluster workflows, changing placement often requires:
+- Editing manifests
+- Reapplying resources
+- Managing clusters individually
+
+With KubeStellar:
+- The workload stays the same
+- Only policy changes
+- Cluster management complexity stays flat as environments grow
+
+---
+
+## Where to go next
+
+You can now:
+
+- Experiment with different BindingPolicy selectors
+- Try adding more clusters
+- Explore how KubeStellar scales across many WECs
+
+To continue learning, check out:
+- https://kubestellar.io
+- https://github.com/kubestellar/kubestellar
+
+Thanks for trying KubeStellar!

--- a/scenarios/bindingpolicy-in-action/index.json
+++ b/scenarios/bindingpolicy-in-action/index.json
@@ -1,0 +1,29 @@
+{
+  "title": "KubeStellar: BindingPolicy in Action",
+  "description": "Learn how changing intent with BindingPolicy changes workload placement without redeploying workloads.",
+  "details": {
+    "intro": {
+      "text": "intro.md"
+    },
+    "steps": [
+      {
+        "title": "Install KubeStellar and Create Clusters",
+        "text": "step1/text.md"
+      },
+      {
+        "title": "Initial Placement Using BindingPolicy",
+        "text": "step2/text.md"
+      },
+      {
+        "title": "Change Intent: Update BindingPolicy",
+        "text": "step3/text.md"
+      }
+    ],
+    "finish": {
+      "text": "finish.md"
+    }
+  },
+  "backend": {
+    "imageid": "ubuntu"
+  }
+}

--- a/scenarios/bindingpolicy-in-action/intro.md
+++ b/scenarios/bindingpolicy-in-action/intro.md
@@ -1,0 +1,41 @@
+# KubeStellar: BindingPolicy in Action
+
+In this scenario, you will see **why BindingPolicy is central to how KubeStellar works**.
+
+In traditional multi-cluster environments, changing where a workload runs usually means:
+- Editing manifests
+- Reapplying resources
+- Managing clusters individually
+
+KubeStellar takes a different approach.
+
+---
+
+## What you will do
+
+In this scenario, you will:
+
+- Install KubeStellar in a fresh environment
+- Create two Workload Execution Clusters (WECs)
+- Deploy a workload **once**
+- Use a BindingPolicy to control where the workload runs
+- Change workload placement **without changing the workload**
+
+---
+
+## What you will NOT do
+
+- You will not redeploy the workload
+- You will not apply manifests directly to WEC clusters
+- You will not manage clusters one by one
+
+All placement changes will be driven by **policy**, not deployment logic.
+
+---
+
+## Key idea to keep in mind
+
+> **BindingPolicy expresses intent.**  
+> When intent changes, behavior changes automatically.
+
+In the next step, you will install KubeStellar and set up a multi-cluster environment.

--- a/scenarios/bindingpolicy-in-action/step1/text.md
+++ b/scenarios/bindingpolicy-in-action/step1/text.md
@@ -1,0 +1,123 @@
+# Install KubeStellar and Create Clusters
+
+In this step, you will install **KubeStellar** and create a multi-cluster environment.
+
+This scenario is **self-contained** and does not rely on any previous scenarios.
+
+---
+
+## Verify Docker is available
+
+KubeStellar uses Kubernetes clusters created with **kind**, which requires Docker.
+
+Verify Docker is available:
+
+```bash
+docker version
+```{}
+
+If this command fails, the scenario cannot proceed.
+
+---
+
+## Install kind (Kubernetes in Docker)
+
+We will use **kind** to create local Kubernetes clusters.
+
+```bash
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+```{}
+
+Verify the installation:
+
+```bash
+kind version
+```{}
+
+---
+
+## Create Kubernetes clusters
+
+Create one hosting cluster and **two Workload Execution Clusters (WECs)**.
+
+```bash
+kind create cluster --name hosting
+kind create cluster --name wec1
+kind create cluster --name wec2
+```{}
+
+Verify the clusters:
+
+```bash
+kind get clusters
+```{}
+
+You should see output similar to:
+hosting
+wec1
+wec2
+
+---
+
+## Install kubectl
+
+Install `kubectl` to interact with the clusters.
+
+```bash
+curl -LO https://dl.k8s.io/release/v1.30.0/bin/linux/amd64/kubectl
+chmod +x kubectl
+sudo mv kubectl /usr/local/bin/
+```{}
+
+Verify the installation:
+
+```bash
+kubectl version --client
+```{}
+
+---
+
+## Install KubeStellar
+
+Clone the KubeStellar repository:
+
+```bash
+git clone https://github.com/kubestellar/kubestellar.git
+cd kubestellar
+```{}
+
+Install KubeStellar using the demo environment script:
+
+```bash
+./scripts/create-kubestellar-demo-env.sh
+```{}
+
+> ⏳ This step may take several minutes to complete.
+
+---
+
+## Verify KubeStellar installation
+
+Check that KubeStellar namespaces exist:
+
+```bash
+kubectl get namespaces
+```{}
+
+Verify that KubeStellar CRDs are installed:
+
+```bash
+kubectl get crds | grep kubestellar
+```{}
+
+Verify that all components are running:
+
+```bash
+kubectl get pods -A
+```{}
+
+At this point, KubeStellar is installed and ready.
+
+Continue to the next step to deploy a workload and control placement using a BindingPolicy.

--- a/scenarios/bindingpolicy-in-action/step2/text.md
+++ b/scenarios/bindingpolicy-in-action/step2/text.md
@@ -1,0 +1,104 @@
+# Initial Placement Using BindingPolicy
+
+In this step, you will deploy a workload **once** and use a **BindingPolicy** to place it on **one Workload Execution Cluster (WEC)**.
+
+Initially, the workload will run only on **wec1**.
+
+---
+
+## Define the workload
+
+Create a simple Deployment.  
+This workload does not reference any cluster.
+
+```bash
+cat <<EOF > workload.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-nginx
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-nginx
+  template:
+    metadata:
+      labels:
+        app: demo-nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:stable
+        ports:
+        - containerPort: 80
+EOF
+```{}
+
+---
+
+## Define a BindingPolicy for a single WEC
+
+Create a BindingPolicy that targets **only `wec1`**.
+
+```bash
+cat <<EOF > bindingpolicy-wec1.yaml
+apiVersion: control.kubestellar.io/v1alpha1
+kind: BindingPolicy
+metadata:
+  name: demo-nginx-to-wec1
+spec:
+  clusterSelectors:
+  - matchLabels:
+      kubestellar.io/cluster-name: wec1
+  downsync:
+  - objectSelectors:
+    - matchLabels:
+        app: demo-nginx
+EOF
+```{}
+
+---
+
+## Apply the workload and policy
+
+Apply both resources **once**, from the control environment.
+
+```bash
+kubectl apply -f workload.yaml
+kubectl apply -f bindingpolicy-wec1.yaml
+```{}
+
+> ⚠️ Do **not** apply these manifests directly to `wec1`.
+> KubeStellar handles distribution automatically.
+
+---
+
+## Observe workload placement
+
+Verify that the workload is running on **wec1**:
+
+```bash
+kubectl --context wec1 get pods
+```{}
+
+You should see a `demo-nginx` pod running.
+
+Now verify that the workload is **not** running on `wec2`:
+
+```bash
+kubectl --context wec2 get pods
+```{}
+
+You should see **no pods** for this workload on `wec2`.
+
+---
+
+## Key takeaway
+
+- The workload was deployed **once**
+- Placement was controlled entirely by **BindingPolicy**
+- The workload runs only where the policy allows
+
+In the next step, you will change **only the BindingPolicy** and observe how placement changes automatically.

--- a/scenarios/bindingpolicy-in-action/step3/text.md
+++ b/scenarios/bindingpolicy-in-action/step3/text.md
@@ -1,0 +1,80 @@
+# Change Intent: Update BindingPolicy
+
+In this step, you will change **only the BindingPolicy** and observe how workload placement changes automatically.
+
+The workload itself will **not** be modified or redeployed.
+
+---
+
+## Remove the existing BindingPolicy
+
+First, delete the BindingPolicy that targets `wec1`.
+
+```bash
+kubectl delete bindingpolicy demo-nginx-to-wec1
+```{}
+
+---
+
+## Define a new BindingPolicy for wec2
+
+Create a new BindingPolicy that targets **only `wec2`**.
+
+```bash
+cat <<EOF > bindingpolicy-wec2.yaml
+apiVersion: control.kubestellar.io/v1alpha1
+kind: BindingPolicy
+metadata:
+  name: demo-nginx-to-wec2
+spec:
+  clusterSelectors:
+  - matchLabels:
+      kubestellar.io/cluster-name: wec2
+  downsync:
+  - objectSelectors:
+    - matchLabels:
+        app: demo-nginx
+EOF
+```{}
+
+---
+
+## Apply the updated BindingPolicy
+
+Apply the new policy from the control environment:
+
+```bash
+kubectl apply -f bindingpolicy-wec2.yaml
+```{}
+
+> The workload manifest has **not** changed.
+
+---
+
+## Observe workload movement
+
+Verify that the workload is **no longer running on `wec1`**:
+
+```bash
+kubectl --context wec1 get pods
+```{}
+
+You should see **no pods** for this workload on `wec1`.
+
+Now verify that the workload is running on **`wec2`**:
+
+```bash
+kubectl --context wec2 get pods
+```{}
+
+You should see the `demo-nginx` pod running on `wec2`.
+
+---
+
+## Key takeaway
+
+- Workload placement changed without redeploying the workload
+- The only change was to **intent**, expressed as a BindingPolicy
+- This is fundamentally different from traditional multi-cluster workflows
+
+Continue to the final step to summarize what you learned.


### PR DESCRIPTION
This PR adds Scenario 2 to the KubeStellar Killercoda tutorials, focusing on why BindingPolicy matters.

The scenario demonstrates how workload placement changes by updating policy only, without modifying or redeploying the workload. It reinforces the intent-driven model at the core of KubeStellar and is fully self-contained.
fixes #8 